### PR TITLE
Update Dependabot to auto-update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,14 @@ updates:
     reviewers:
       - "bajtos"
       - "juliangruber"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/Berlin"
+    commit-message:
+      prefix: "ci"
+    reviewers:
+      - "bajtos"
+      - "juliangruber"


### PR DESCRIPTION
Fixes [#242](https://github.com/CheckerNetwork/roadmap/issues/242)